### PR TITLE
Small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@
 servers.csv:
 	echo 'name,url,location' > servers.csv
 	curl https://galaxyproject.org/use/feed.json | \
-		jq -r '.[] | select(.platforms[].platform_group == "public-server") | [.title, .url, .platforms[].platform_location | select(. != null)] | @csv' | \
+		jq -r '.[] | select(.platforms[].platform_group == "public-server") | [.title, .platforms[].platform_url, .platforms[].platform_location | select(. != null)] | @csv' | \
 		sed 's/"//g' | \
 		sort >> servers.csv

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@
 servers.csv:
 	echo 'name,url,location' > servers.csv
 	curl https://galaxyproject.org/use/feed.json | \
-		jq -r '.[] | select(.platforms[].platform_group == "public-server") | [.title, .platforms[].platform_url, .platforms[].platform_location | select(. != null)] | @csv' | \
+		jq -r '.[] | select(.platforms[].platform_group == "public-server") | [.title, (.platforms[] | select(.platform_group == "public-server").platform_url), .platforms[].platform_location | select(. != null)] | @csv' | \
 		sed 's/"//g' | \
 		sort >> servers.csv

--- a/process.py
+++ b/process.py
@@ -171,7 +171,7 @@ def process_url(url):
 
     tools = 0
     lookslikegalaxy = False
-    if response_index is not None and response_index.ok and ('window.Galaxy' in response_index.text or 'toolbox_in_panel' in response_index.text):
+    if response_index is not None and response_index.ok and ('window.Galaxy' in response_index.text or 'toolbox_in_panel' in response_index.text or 'The Galaxy analysis interface' in response_index.text):
         lookslikegalaxy = True
 
         (response, data) = req_json_safe(url + '/api/tools')


### PR DESCRIPTION
Hi!
2 small fixes:
- bipaa or usegalaxy-p was shown as down on grafana
- the tools number was often 0 because the code that detects if the url is a galaxy server failed (maybe due to recent release?)
Should fix at least problems with genouest and bipaa servers on https://stats.galaxyproject.eu